### PR TITLE
WIP: Cube and Display modes

### DIFF
--- a/include/display/DisplayManager.h
+++ b/include/display/DisplayManager.h
@@ -14,6 +14,12 @@ static constexpr int ONE_LINE_SPACE = 20;
 static constexpr int TWO_LINES_SPACE = 40;
 static constexpr int THREE_LINES_SPACE = 60;
 
+typedef enum {
+    DISPLAY_MODE_NONE,  // not any particular display mode, used for manually controlling the LCD
+    DISPLAY_MODE_GIF,   // displays a GIF
+    DISPLAY_MODE_CUBE   // displays a rotating cube
+} displayMode_e;
+
 class DisplayManager {
    public:
     static void begin();
@@ -27,6 +33,6 @@ class DisplayManager {
                                uint16_t fgColor = 0x07E0, uint16_t bgColor = 0x39E7);
     static bool playGifFullScreen(const String& path, uint32_t timeMs = 0);
     static bool stopGif();
-    static void update();
+    static void update(displayMode_e mode);
     static void clearScreen();
 };

--- a/include/display/cube.h
+++ b/include/display/cube.h
@@ -1,0 +1,19 @@
+#ifndef SRC_DISPLAY_CUBE_H
+#define SRC_DISPLAY_CUBE_H
+
+#include <Arduino.h>
+
+class Cube {
+   public:
+    Cube();
+    void draw();
+    void setRotX(float newRot);
+    void setRotY(float newRot);
+
+    // current cube rotation
+    float rotX;
+    float rotY;
+    float rotZ;
+};
+
+#endif

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -5,14 +5,18 @@
 #include "display/DisplayManager.h"
 #include "display/GeekMagicSPIBus.h"
 #include "config/ConfigManager.h"
+#include "wireless/WiFiManager.h"
 #include "display/Gif.h"
+#include "display/cube.h"
 
 static Gif s_gif;
+static Cube s_cube;
 
+extern WiFiManager* wifiManager;
 extern ConfigManager configManager;
 
 static Arduino_DataBus* g_lcdBus = nullptr;
-static Arduino_GFX* g_lcd = nullptr;
+Arduino_GFX* g_lcd = nullptr;
 static bool g_lcdReady = false;
 static bool g_lcdInitializing = false;
 static uint32_t g_lcdInitAttempts = 0;
@@ -740,7 +744,24 @@ auto DisplayManager::stopGif() -> bool {
     return true;
 }
 
-auto DisplayManager::update() -> void { s_gif.update(); }
+/**
+ * @brief Called per update loop in main, handles re-drawing the screen
+ */
+auto DisplayManager::update(displayMode_e mode) -> void {
+    switch (mode) {
+        case DISPLAY_MODE_GIF:
+            s_gif.update();
+            break;
+        case DISPLAY_MODE_CUBE:
+            clearScreen();
+            s_cube.setRotX(s_cube.rotX + 1);
+            s_cube.setRotY(s_cube.rotY + 2);
+            s_cube.draw();
+            break;
+        default:
+            break;
+    }
+}
 
 /**
  * @brief Clear the entire display to black

--- a/src/display/cube.cpp
+++ b/src/display/cube.cpp
@@ -1,0 +1,116 @@
+/**
+ * cube.cpp, by electro707
+ *
+ * This was ported from one of my projects, thus why it's mostly c-like with little classes and a self-made matrix
+ *  multiplication math
+ */
+#include "display/cube.h"
+#include "display/DisplayManager.h"
+#include "config/ConfigManager.h"
+#include <Arduino_GFX_Library.h>
+
+#define CUBE_MATRIX_ROWS 10
+
+// the cube matrix,
+float cubePositions[CUBE_MATRIX_ROWS * 4] = {
+    -1, 1, -1, 1, 1, 1, -1, 1, 1, -1, -1, 1, -1, -1, -1, 1, -1, 1, -1, 1,
+    -1, 1, 1,  1, 1, 1, 1,  1, 1, -1, 1,  1, -1, -1, 1,  1, -1, 1, 1,  1,
+};
+
+typedef struct {
+    u32 rows;
+    u32 cols;
+} matrixSize_s;
+
+extern Arduino_GFX* g_lcd;
+extern ConfigManager configManager;
+
+// self-made matrix multiplication
+void matrixMult(float* srcA, float* srcB, float* dst, matrixSize_s sizeA, matrixSize_s sizeB) {
+    float sum;
+
+    assert(sizeA.cols == sizeB.rows);
+
+    u32 m = sizeA.rows;
+    u32 p = sizeB.cols;
+    u32 n = sizeA.cols;
+
+    memset(dst, 0, m * p * sizeof(float));
+
+    for (u32 i = 0; i < m; i++) {
+        for (u32 j = 0; j < p; j++) {
+            sum = 0;
+            for (u32 k = 0; k < n; k++) {
+                sum += srcA[k + (i * sizeA.cols)] * srcB[j + (k * sizeB.cols)];
+            }
+            dst[(i * sizeB.cols) + j] = sum;
+        }
+    }
+}
+
+void rotateCube(float rotX, float rotY, float rotZ, float* newCube) {
+    float tmpA[4 * CUBE_MATRIX_ROWS];
+    float tmpB[4 * CUBE_MATRIX_ROWS];
+
+    rotX = rotX * (M_PI / 180);
+    rotY = rotY * (M_PI / 180);
+    rotZ = rotZ * (M_PI / 180);
+
+    float rotationMatrixX[4 * 4] = {
+        1, 0, 0, 0, 0, cos(rotX), -sin(rotX), 0, 0, sin(rotX), cos(rotX), 0, 0, 0, 0, 1,
+    };
+    float rotationMatrixY[4 * 4] = {
+        cos(rotY), 0, sin(rotY), 0, 0, 1, 0, 0, -sin(rotY), 0, cos(rotY), 0, 0, 0, 0, 1,
+    };
+    float rotationMatrixZ[4 * 4] = {
+        cos(rotZ), -sin(rotZ), 0, 0, sin(rotZ), cos(rotZ), 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+    };
+
+    matrixMult(cubePositions, rotationMatrixX, tmpA, (matrixSize_s){CUBE_MATRIX_ROWS, 4}, (matrixSize_s){4, 4});
+    matrixMult(tmpA, rotationMatrixY, tmpB, (matrixSize_s){CUBE_MATRIX_ROWS, 4}, (matrixSize_s){4, 4});
+    matrixMult(tmpB, rotationMatrixZ, newCube, (matrixSize_s){CUBE_MATRIX_ROWS, 4}, (matrixSize_s){4, 4});
+}
+
+/**
+ * @brief This function takes a float position and converts it to on-screen coordinates
+ *
+ * Because the screen for this firmware will always be 240x240, this works
+ *
+ * todo: have this use globally defined LCD, but NOT through the config (no need, static display size)
+ */
+u32 scaleVectorToDraw(float pos) {
+    return (pos * (configManager.getLCDWidthSafe() / 4)) + (configManager.getLCDWidthSafe() / 2);
+}
+
+Cube::Cube() {}
+
+auto Cube::setRotX(float newRot) -> void { rotX = newRot; }
+auto Cube::setRotY(float newRot) -> void { rotY = newRot; }
+
+auto Cube::draw(void) -> void {
+    float* pos;
+    float* posNext;
+    float cube[CUBE_MATRIX_ROWS * 4];
+
+    rotateCube(rotX, rotY, rotZ, cube);
+
+    // draw the top and bottom squares
+    for (int side = 0; side < 2; side++) {
+        for (int i = 0; i < 4; i++) {
+            pos = &cube[(4 * i) + (side * 5 * 4)];
+            posNext = &cube[4 * (i + 1) + (side * 5 * 4)];
+
+            g_lcd->drawLine(scaleVectorToDraw(pos[0]), scaleVectorToDraw(pos[1]), scaleVectorToDraw(posNext[0]),
+                            scaleVectorToDraw(posNext[1]), LCD_WHITE);
+        }
+    }
+
+    // draw the 4 lines connecting them
+    for (int p = 0; p < 4; p++) {
+        pos = &cube[4 * p];
+        posNext = &cube[4 * (p + 5)];
+
+        g_lcd->drawLine(scaleVectorToDraw(pos[0]), scaleVectorToDraw(pos[1]), scaleVectorToDraw(posNext[0]),
+                        scaleVectorToDraw(posNext[1]), LCD_WHITE);
+    }
+}

--- a/src/display/cube.cpp
+++ b/src/display/cube.cpp
@@ -94,14 +94,16 @@ auto Cube::draw(void) -> void {
 
     rotateCube(rotX, rotY, rotZ, cube);
 
+    g_lcd->startWrite();
+
     // draw the top and bottom squares
     for (int side = 0; side < 2; side++) {
         for (int i = 0; i < 4; i++) {
             pos = &cube[(4 * i) + (side * 5 * 4)];
             posNext = &cube[4 * (i + 1) + (side * 5 * 4)];
 
-            g_lcd->drawLine(scaleVectorToDraw(pos[0]), scaleVectorToDraw(pos[1]), scaleVectorToDraw(posNext[0]),
-                            scaleVectorToDraw(posNext[1]), LCD_WHITE);
+            g_lcd->writeLine(scaleVectorToDraw(pos[0]), scaleVectorToDraw(pos[1]), scaleVectorToDraw(posNext[0]),
+                             scaleVectorToDraw(posNext[1]), LCD_WHITE);
         }
     }
 
@@ -110,7 +112,9 @@ auto Cube::draw(void) -> void {
         pos = &cube[4 * p];
         posNext = &cube[4 * (p + 5)];
 
-        g_lcd->drawLine(scaleVectorToDraw(pos[0]), scaleVectorToDraw(pos[1]), scaleVectorToDraw(posNext[0]),
-                        scaleVectorToDraw(posNext[1]), LCD_WHITE);
+        g_lcd->writeLine(scaleVectorToDraw(pos[0]), scaleVectorToDraw(pos[1]), scaleVectorToDraw(posNext[0]),
+                         scaleVectorToDraw(posNext[1]), LCD_WHITE);
     }
+
+    g_lcd->endWrite();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "config/ConfigManager.h"
 #include "wireless/WiFiManager.h"
 #include "display/DisplayManager.h"
+#include "display/cube.h"
 #include "web/Webserver.h"
 #include "web/Api.h"
 
@@ -24,6 +25,8 @@ static constexpr int LOADING_BAR_Y = 110;
 static constexpr int LOADING_DELAY_MS = 1000;
 
 Webserver* webserver = nullptr;
+
+displayMode_e displayMode = DISPLAY_MODE_NONE;
 
 /**
  * @brief Initializes the system
@@ -97,11 +100,12 @@ void setup() {
     delay(LOADING_DELAY_MS);
 
     DisplayManager::drawStartup(wifiManager->getIP().toString());
+    displayMode = DISPLAY_MODE_CUBE;
 }
 
 void loop() {
     if (webserver != nullptr) {
         webserver->handleClient();
     }
-    DisplayManager::update();
+    DisplayManager::update(displayMode);
 }


### PR DESCRIPTION
This PR does one of two things:
- Adds a cool rotating cube
- Primes `displayManager.cpp` to be able to show different modes, which will be useful for future stuff like a clock and whatnot.

The cube is home-brewed from another project of mine, which is why a lot of the inner code is in C-like fashion, and why I am doing the matrix multiplication myself.

TODO before merge for myself:
- either add some option to set the mode, or at least revert back to GIF mode before merging
- So technically my math can support any object that is exported from Blender in an obj format, so maybe as a longer stretch goal I add the option to upload an OBJ file and have it drawn.

The cube right now looks...choppy. That is because I have no rate limiter, and more importantly I have to clear the screen each time before drawing, and due to the lack of a VSYNC signal I may be updating the display when it should be drawing.
One possibility to partially fix this is to have a global framebuffer that is updated then drawn into.

https://github.com/user-attachments/assets/9a8ff407-3872-42ae-80e1-2dacbe5dda31

