### PR TITLE
feat: add optional system metrics dashboard

### DIFF
--- a/include/dashboard/DashboardManager.h
+++ b/include/dashboard/DashboardManager.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <Arduino.h>
+
+class DashboardManager {
+   public:
+    static void begin(const char* metricsUrl);
+    static void update();
+};

--- a/readme.md
+++ b/readme.md
@@ -431,6 +431,32 @@ This project is licensed under the **GPLv3 License** - see the [LICENSE](LICENSE
 
 [Star us on GitHub](https://github.com/Times-Z/GeekMagic-Open-Firmware.git) if you find this project useful !
 
+## Optional system metrics dashboard
+
+The firmware can display a compact six-value PC metrics dashboard instead of the normal content loop. It is disabled by default, so existing builds keep their current behavior.
+
+Enable it by appending `METRICS_URL` to the existing `build_flags` in `platformio.ini`:
+
+```ini
+-DMETRICS_URL=\"http://192.168.1.10:8765/metrics\"
+```
+
+The endpoint is polled once per second and must return JSON with these fields:
+
+```json
+{
+  "ok": true,
+  "gpu_usage": 28,
+  "cpu_usage": 24,
+  "gpu_vram_mb": 6930,
+  "memory_used_gb": 36.8,
+  "gpu_power": 45,
+  "gpu_temp_c": 50
+}
+```
+
+Only changed value regions are redrawn, preventing the full-screen flash that would otherwise occur during one-second updates. If the endpoint or Wi-Fi is unavailable, the display shows `PC OFFLINE`.
+
 This project took me a lot of time !
 
 </div>

--- a/src/dashboard/DashboardManager.cpp
+++ b/src/dashboard/DashboardManager.cpp
@@ -5,12 +5,16 @@
 #include <ESP8266HTTPClient.h>
 #include <ESP8266WiFi.h>
 #include <WiFiClient.h>
+#include <array>
 #include <cstring>
 
 #include "display/DisplayManager.h"
 
 namespace {
 constexpr uint32_t FETCH_INTERVAL_MS = 1000;
+constexpr uint16_t FETCH_TIMEOUT_MS = 800;
+constexpr size_t TILE_COUNT = 6;
+constexpr size_t VALUE_TEXT_SIZE = 12;
 constexpr uint16_t COLOR_BG = 0x0841;
 constexpr uint16_t COLOR_HEADER = 0x18E3;
 constexpr uint16_t COLOR_PANEL = 0x2104;
@@ -27,7 +31,7 @@ String metricsUrl;
 uint32_t lastFetch = 0;
 bool offlineDrawn = false;
 bool dashboardDrawn = false;
-char lastValues[6][12] = {};
+std::array<std::array<char, VALUE_TEXT_SIZE>, TILE_COUNT> lastValues{};
 
 struct Metrics {
     float gpuUsage = 0;
@@ -38,6 +42,9 @@ struct Metrics {
     float gpuTemp = 0;
 } data;
 
+// The dashboard is a fixed 240x240 pixel layout. Keeping its literal geometry
+// together makes the drawing code easier to compare with the physical screen.
+// NOLINTBEGIN(readability-magic-numbers,bugprone-narrowing-conversions)
 void drawHeader(bool live) {
     auto* gfx = DisplayManager::getGfx();
     gfx->fillRect(0, 0, 240, 26, COLOR_HEADER);
@@ -50,19 +57,19 @@ void drawHeader(bool live) {
     gfx->print(live ? "LIVE" : "OFF");
 }
 
-void drawTileFrame(int16_t x, int16_t y, const char* label, const char* unit, uint16_t accent) {
+void drawTileFrame(int16_t xPos, int16_t yPos, const char* label, const char* unit, uint16_t accent) {
     auto* gfx = DisplayManager::getGfx();
     constexpr int16_t width = 113;
     constexpr int16_t height = 65;
-    gfx->fillRoundRect(x, y, width, height, 4, COLOR_PANEL);
-    gfx->drawRoundRect(x, y, width, height, 4, COLOR_BORDER);
-    gfx->fillRect(x + 1, y + 1, 4, height - 2, accent);
+    gfx->fillRoundRect(xPos, yPos, width, height, 4, COLOR_PANEL);
+    gfx->drawRoundRect(xPos, yPos, width, height, 4, COLOR_BORDER);
+    gfx->fillRect(xPos + 1, yPos + 1, 4, height - 2, accent);
     gfx->setTextColor(COLOR_MUTED, COLOR_PANEL);
     gfx->setTextSize(1);
-    gfx->setCursor(x + 12, y + 8);
+    gfx->setCursor(xPos + 12, yPos + 8);
     gfx->print(label);
     gfx->setTextColor(accent, COLOR_PANEL);
-    gfx->setCursor(x + 88, y + 47);
+    gfx->setCursor(xPos + 88, yPos + 47);
     gfx->print(unit);
 }
 
@@ -72,20 +79,20 @@ void resetValueCache() {
     }
 }
 
-void updateTileValue(uint8_t index, int16_t x, int16_t y, float value, uint8_t decimals) {
-    char valueText[12];
-    dtostrf(value, 0, decimals, valueText);
-    if (std::strcmp(lastValues[index], valueText) == 0) {
+void updateTileValue(uint8_t index, int16_t xPos, int16_t yPos, float value, uint8_t decimals) {
+    std::array<char, VALUE_TEXT_SIZE> valueText{};
+    dtostrf(value, 0, decimals, valueText.data());
+    if (std::strcmp(lastValues[index].data(), valueText.data()) == 0) {
         return;
     }
     auto* gfx = DisplayManager::getGfx();
-    gfx->fillRect(x + 8, y + 25, 78, 35, COLOR_PANEL);
+    gfx->fillRect(xPos + 8, yPos + 25, 78, 35, COLOR_PANEL);
     gfx->setTextColor(LCD_WHITE, COLOR_PANEL);
     gfx->setTextSize(3);
-    gfx->setCursor(x + 11, y + 28);
-    gfx->print(valueText);
-    std::strncpy(lastValues[index], valueText, sizeof(lastValues[index]) - 1);
-    lastValues[index][sizeof(lastValues[index]) - 1] = '\0';
+    gfx->setCursor(xPos + 11, yPos + 28);
+    gfx->print(valueText.data());
+    std::strncpy(lastValues[index].data(), valueText.data(), lastValues[index].size() - 1);
+    lastValues[index].back() = '\0';
 }
 
 void drawDashboardFrame() {
@@ -127,14 +134,15 @@ void drawOffline() {
     dashboardDrawn = false;
     resetValueCache();
 }
+// NOLINTEND(readability-magic-numbers,bugprone-narrowing-conversions)
 
-bool fetchMetrics() {
+auto fetchMetrics() -> bool {
     if (WiFi.status() != WL_CONNECTED) {
         return false;
     }
     WiFiClient client;
     HTTPClient http;
-    http.setTimeout(800);
+    http.setTimeout(FETCH_TIMEOUT_MS);
     if (!http.begin(client, metricsUrl)) {
         return false;
     }
@@ -146,7 +154,7 @@ bool fetchMetrics() {
     JsonDocument doc;
     const DeserializationError error = deserializeJson(doc, http.getStream());
     http.end();
-    if (error || !(doc["ok"] | false)) {
+    if (error || !doc["ok"].as<bool>()) {
         return false;
     }
     data.gpuUsage = doc["gpu_usage"] | 0.0F;

--- a/src/dashboard/DashboardManager.cpp
+++ b/src/dashboard/DashboardManager.cpp
@@ -154,16 +154,16 @@ auto fetchMetrics() -> bool {
     JsonDocument doc;
     const DeserializationError error = deserializeJson(doc, http.getStream());
     http.end();
-    if (error || !doc["ok"].as<bool>()) {
-        return false;
+    const bool responseOk = !error && doc["ok"].as<bool>();
+    if (responseOk) {
+        data.gpuUsage = doc["gpu_usage"] | 0.0F;
+        data.cpuUsage = doc["cpu_usage"] | 0.0F;
+        data.gpuVramMb = doc["gpu_vram_mb"] | 0.0F;
+        data.memoryUsedGb = doc["memory_used_gb"] | 0.0F;
+        data.gpuPower = doc["gpu_power"] | 0.0F;
+        data.gpuTemp = doc["gpu_temp_c"] | 0.0F;
     }
-    data.gpuUsage = doc["gpu_usage"] | 0.0F;
-    data.cpuUsage = doc["cpu_usage"] | 0.0F;
-    data.gpuVramMb = doc["gpu_vram_mb"] | 0.0F;
-    data.memoryUsedGb = doc["memory_used_gb"] | 0.0F;
-    data.gpuPower = doc["gpu_power"] | 0.0F;
-    data.gpuTemp = doc["gpu_temp_c"] | 0.0F;
-    return true;
+    return responseOk;
 }
 }  // namespace
 

--- a/src/dashboard/DashboardManager.cpp
+++ b/src/dashboard/DashboardManager.cpp
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "dashboard/DashboardManager.h"
+
+#include <ArduinoJson.h>
+#include <ESP8266HTTPClient.h>
+#include <ESP8266WiFi.h>
+#include <WiFiClient.h>
+#include <cstring>
+
+#include "display/DisplayManager.h"
+
+namespace {
+constexpr uint32_t FETCH_INTERVAL_MS = 1000;
+constexpr uint16_t COLOR_BG = 0x0841;
+constexpr uint16_t COLOR_HEADER = 0x18E3;
+constexpr uint16_t COLOR_PANEL = 0x2104;
+constexpr uint16_t COLOR_BORDER = 0x39E7;
+constexpr uint16_t COLOR_MUTED = 0xA514;
+constexpr uint16_t COLOR_GPU = 0xF926;
+constexpr uint16_t COLOR_CPU = 0xFD20;
+constexpr uint16_t COLOR_VRAM = 0xFDE0;
+constexpr uint16_t COLOR_RAM = 0xA81F;
+constexpr uint16_t COLOR_POWER = 0xFA80;
+constexpr uint16_t COLOR_TEMP = 0x3DDF;
+
+String metricsUrl;
+uint32_t lastFetch = 0;
+bool offlineDrawn = false;
+bool dashboardDrawn = false;
+char lastValues[6][12] = {};
+
+struct Metrics {
+    float gpuUsage = 0;
+    float cpuUsage = 0;
+    float gpuVramMb = 0;
+    float memoryUsedGb = 0;
+    float gpuPower = 0;
+    float gpuTemp = 0;
+} data;
+
+void drawHeader(bool live) {
+    auto* gfx = DisplayManager::getGfx();
+    gfx->fillRect(0, 0, 240, 26, COLOR_HEADER);
+    gfx->setTextColor(LCD_WHITE, COLOR_HEADER);
+    gfx->setTextSize(1);
+    gfx->setCursor(9, 9);
+    gfx->print("SYSTEM METRICS");
+    gfx->setTextColor(live ? LCD_GREEN : LCD_RED, COLOR_HEADER);
+    gfx->setCursor(207, 9);
+    gfx->print(live ? "LIVE" : "OFF");
+}
+
+void drawTileFrame(int16_t x, int16_t y, const char* label, const char* unit, uint16_t accent) {
+    auto* gfx = DisplayManager::getGfx();
+    constexpr int16_t width = 113;
+    constexpr int16_t height = 65;
+    gfx->fillRoundRect(x, y, width, height, 4, COLOR_PANEL);
+    gfx->drawRoundRect(x, y, width, height, 4, COLOR_BORDER);
+    gfx->fillRect(x + 1, y + 1, 4, height - 2, accent);
+    gfx->setTextColor(COLOR_MUTED, COLOR_PANEL);
+    gfx->setTextSize(1);
+    gfx->setCursor(x + 12, y + 8);
+    gfx->print(label);
+    gfx->setTextColor(accent, COLOR_PANEL);
+    gfx->setCursor(x + 88, y + 47);
+    gfx->print(unit);
+}
+
+void resetValueCache() {
+    for (auto& value : lastValues) {
+        value[0] = '\0';
+    }
+}
+
+void updateTileValue(uint8_t index, int16_t x, int16_t y, float value, uint8_t decimals) {
+    char valueText[12];
+    dtostrf(value, 0, decimals, valueText);
+    if (std::strcmp(lastValues[index], valueText) == 0) {
+        return;
+    }
+    auto* gfx = DisplayManager::getGfx();
+    gfx->fillRect(x + 8, y + 25, 78, 35, COLOR_PANEL);
+    gfx->setTextColor(LCD_WHITE, COLOR_PANEL);
+    gfx->setTextSize(3);
+    gfx->setCursor(x + 11, y + 28);
+    gfx->print(valueText);
+    std::strncpy(lastValues[index], valueText, sizeof(lastValues[index]) - 1);
+    lastValues[index][sizeof(lastValues[index]) - 1] = '\0';
+}
+
+void drawDashboardFrame() {
+    auto* gfx = DisplayManager::getGfx();
+    gfx->fillScreen(COLOR_BG);
+    drawHeader(true);
+    drawTileFrame(5, 31, "GPU LOAD", "%", COLOR_GPU);
+    drawTileFrame(122, 31, "CPU LOAD", "%", COLOR_CPU);
+    drawTileFrame(5, 101, "VRAM USED", "GB", COLOR_VRAM);
+    drawTileFrame(122, 101, "RAM USED", "GB", COLOR_RAM);
+    drawTileFrame(5, 171, "GPU POWER", "W", COLOR_POWER);
+    drawTileFrame(122, 171, "GPU TEMP", "C", COLOR_TEMP);
+    resetValueCache();
+    dashboardDrawn = true;
+}
+
+void updateDashboardValues() {
+    updateTileValue(0, 5, 31, data.gpuUsage, 0);
+    updateTileValue(1, 122, 31, data.cpuUsage, 0);
+    updateTileValue(2, 5, 101, data.gpuVramMb / 1024.0F, 1);
+    updateTileValue(3, 122, 101, data.memoryUsedGb, 1);
+    updateTileValue(4, 5, 171, data.gpuPower, 0);
+    updateTileValue(5, 122, 171, data.gpuTemp, 0);
+}
+
+void drawOffline() {
+    auto* gfx = DisplayManager::getGfx();
+    gfx->fillScreen(COLOR_BG);
+    drawHeader(false);
+    gfx->setTextColor(LCD_WHITE, COLOR_BG);
+    gfx->setTextSize(2);
+    gfx->setCursor(49, 91);
+    gfx->print("PC OFFLINE");
+    gfx->setTextColor(COLOR_MUTED, COLOR_BG);
+    gfx->setTextSize(1);
+    gfx->setCursor(38, 126);
+    gfx->print("Check service or WiFi");
+    offlineDrawn = true;
+    dashboardDrawn = false;
+    resetValueCache();
+}
+
+bool fetchMetrics() {
+    if (WiFi.status() != WL_CONNECTED) {
+        return false;
+    }
+    WiFiClient client;
+    HTTPClient http;
+    http.setTimeout(800);
+    if (!http.begin(client, metricsUrl)) {
+        return false;
+    }
+    const int status = http.GET();
+    if (status != HTTP_CODE_OK) {
+        http.end();
+        return false;
+    }
+    JsonDocument doc;
+    const DeserializationError error = deserializeJson(doc, http.getStream());
+    http.end();
+    if (error || !(doc["ok"] | false)) {
+        return false;
+    }
+    data.gpuUsage = doc["gpu_usage"] | 0.0F;
+    data.cpuUsage = doc["cpu_usage"] | 0.0F;
+    data.gpuVramMb = doc["gpu_vram_mb"] | 0.0F;
+    data.memoryUsedGb = doc["memory_used_gb"] | 0.0F;
+    data.gpuPower = doc["gpu_power"] | 0.0F;
+    data.gpuTemp = doc["gpu_temp_c"] | 0.0F;
+    return true;
+}
+}  // namespace
+
+void DashboardManager::begin(const char* url) {
+    metricsUrl = url;
+    lastFetch = millis() - FETCH_INTERVAL_MS;
+    drawOffline();
+}
+
+void DashboardManager::update() {
+    const uint32_t now = millis();
+    if (now - lastFetch < FETCH_INTERVAL_MS) {
+        return;
+    }
+    lastFetch = now;
+    if (!fetchMetrics()) {
+        if (!offlineDrawn) {
+            drawOffline();
+        }
+        return;
+    }
+    offlineDrawn = false;
+    if (!dashboardDrawn) {
+        drawDashboardFrame();
+    }
+    updateDashboardValues();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,12 @@
 #include "web/Api.h"
 #include "ntp/NTPClient.h"
 #include "boot/RescueMode.h"
+#include "dashboard/DashboardManager.h"
 #include <array>
+
+#ifndef METRICS_URL
+#define METRICS_URL ""
+#endif
 
 ConfigManager configManager;
 const char* AP_SSID = "GeekMagic";
@@ -50,6 +55,7 @@ static constexpr int LOADING_BAR_TEXT_X = 50;
 static constexpr int LOADING_BAR_TEXT_Y = 80;
 static constexpr int LOADING_BAR_Y = 110;
 static constexpr int LOADING_DELAY_MS = 1000;
+static constexpr const char* METRICS_ENDPOINT = METRICS_URL;
 
 Webserver* webserver = nullptr;
 NTPClient* ntpClient = nullptr;
@@ -175,6 +181,10 @@ void setup() {
 
     DisplayManager::drawStartup(wifiManager->getIP().toString());
 
+    if (METRICS_ENDPOINT[0] != '\0' && wifiManager->isConnected() && !wifiManager->isApMode()) {
+        DashboardManager::begin(METRICS_ENDPOINT);
+    }
+
     // enable watchdog before going to loop()
     // 2 seconds should be way more than the main loop needs to do stuff
     EspClass::wdtEnable(WDTO_2S);
@@ -201,6 +211,11 @@ void loop() {
     }
 
     DisplayManager::update();
+
+    if (METRICS_ENDPOINT[0] != '\0' && wifiManager != nullptr && wifiManager->isConnected() &&
+        !wifiManager->isApMode()) {
+        DashboardManager::update();
+    }
 
     static unsigned long last_free_heap_log = 0;
     static constexpr unsigned long FREE_HEAP_LOG_INTERVAL_MS = 10000UL;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,7 +181,7 @@ void setup() {
 
     DisplayManager::drawStartup(wifiManager->getIP().toString());
 
-    if (METRICS_ENDPOINT[0] != '\0' && wifiManager->isConnected() && !wifiManager->isApMode()) {
+    if (METRICS_ENDPOINT[0] != '\0' && WiFiManager::isConnected() && !wifiManager->isApMode()) {
         DashboardManager::begin(METRICS_ENDPOINT);
     }
 
@@ -212,7 +212,7 @@ void loop() {
 
     DisplayManager::update();
 
-    if (METRICS_ENDPOINT[0] != '\0' && wifiManager != nullptr && wifiManager->isConnected() &&
+    if (METRICS_ENDPOINT[0] != '\0' && wifiManager != nullptr && WiFiManager::isConnected() &&
         !wifiManager->isApMode()) {
         DashboardManager::update();
     }


### PR DESCRIPTION
## Summary

- add an optional 240x240 system metrics dashboard for GPU load, CPU load, VRAM, RAM, GPU power, and GPU temperature
- poll a configurable JSON endpoint once per second
- redraw only changed value regions to avoid visible full-screen flashing
- preserve the existing firmware behavior when `METRICS_URL` is not defined
- show a clear offline state when Wi-Fi or the metrics endpoint is unavailable

## Motivation

The HelloCubic Lite works well as a compact PC monitoring display, but rapidly updating a full screen once per second produces visible flicker. This adds an opt-in dashboard with cached values and partial redraws, while keeping the normal content loop unchanged for default builds.

## Configuration

Append a build flag such as:

```ini
-DMETRICS_URL=\"http://192.168.1.10:8765/metrics\"
```

The expected JSON contract is documented in the README.

## Validation

- PlatformIO default build: success, 52.5% RAM / 42.3% flash
- PlatformIO build with `METRICS_URL`: success, 53.0% RAM / 43.4% flash
- tested on ESP8266 HelloCubic Lite hardware with one-second live updates
